### PR TITLE
Bug 1620932: Fix React warning in devtools/client/responsive/components/Browser.js `allowFullScreen: "true"`

### DIFF
--- a/devtools/client/responsive/components/Browser.js
+++ b/devtools/client/responsive/components/Browser.js
@@ -160,7 +160,7 @@ class Browser extends PureComponent {
     // access to browser features as regular browser tabs. The `swapFrameLoaders` platform
     // API we use compares such features before allowing the swap to proceed.
     return dom.iframe({
-      allowFullScreen: "true",
+      allowFullScreen: true,
       className: "browser",
       height: "100%",
       mozbrowser: "true",


### PR DESCRIPTION
Bug 1620932 fix as per https://bugzilla.mozilla.org/show_bug.cgi?id=1620932